### PR TITLE
Use newly added flag of helm lint, --strict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,25 @@ go:
   - 1.6
 
 before_install:
+  - pushd /tmp/
   - export GLIDE_VERSION="0.10.1"
   - ls $GOPATH/src/
   - wget "https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz"
   - mkdir -p $HOME/bin
   - tar -vxz -C $HOME/bin --strip=1 -f glide-$GLIDE_VERSION-linux-amd64.tar.gz
   - export PATH="$HOME/bin:$PATH" GLIDE_HOME="$HOME/.glide"
+  - popd
 
 install:
-  - cd $GOPATH/src/
+  - pushd $GOPATH/src/
   - mkdir k8s.io && cd k8s.io
   - git clone https://github.com/kubernetes/helm
   - cd helm && make bootstrap build
   - mv bin/helm $HOME/bin
+  - popd
 
 script:
-  - helm lint *
+  - helm lint * --strict
 
 after_success:
   # TODO: run sync-repo script with gs://kubernetes-charts on green master build


### PR DESCRIPTION
This flag makes lint fail on warnings which raises useful validation messages needed to be cared. Also it makes CI actually work as before this it was scanning a wrong folder.
See also: https://github.com/kubernetes/helm/pull/1019
